### PR TITLE
Allow post <xs:id> to be 0

### DIFF
--- a/1.3-proposed/wxr.xsd
+++ b/1.3-proposed/wxr.xsd
@@ -452,7 +452,7 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:all>
-			<xs:element name='id' type='xs:positiveInteger'>
+			<xs:element name='id' type='xs:nonNegativeInteger'>
 				<xs:annotation>
 					<xs:documentation>
 						Represents the ID of the WP_Post.


### PR DESCRIPTION
WXR is a format defining export and import.
During a WordPress export 0 is not a valid value.
But an import may originate from a non-WordPress source (eg: another CMS).
In most case such posts will be numbered too what would easily map to WordPress `<xs:id>`.
But in WordPress, (file) attachments are also _WP_post_  and attachment from incoming source may not having unique identifiers or identifiers not being integers.
Having to generate random integers is not logical.

That would makes sense to allow `<xs:id>` to be 0 for imported WXR files.